### PR TITLE
Add TestGenerationHelper class for generating PHPUnit test classes

### DIFF
--- a/src/GeneratorHelpers/ClassGenerationHelper.php
+++ b/src/GeneratorHelpers/ClassGenerationHelper.php
@@ -47,10 +47,11 @@ class ClassGenerationHelper extends MethodGenerationHelper
         $namespaceNode = $this->factory->namespace($namespace);
 
         foreach ($imports as $import) {
-            $namespaceNode->addStmt($this->factory->use($import));
+            $useStmt = $this->factory->use($import);
+            $namespaceNode->addStmt($useStmt);
         }
 
-        $namespaceNode->addStmt($class);
+        $namespaceNode->addStmt($class->getNode());
 
         return $namespaceNode;
     }

--- a/src/GeneratorHelpers/TestGenerationHelper.php
+++ b/src/GeneratorHelpers/TestGenerationHelper.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace quintenmbusiness\PhpAstCodeGenerationHelper\GeneratorHelpers;
+
+use PhpParser\Builder\Class_;
+use PhpParser\Builder\Method;
+use PhpParser\Builder\Namespace_;
+use PhpParser\BuilderFactory;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt;
+use PhpParser\Node\Stmt\Expression;
+
+class TestGenerationHelper extends ClassGenerationHelper
+{
+    /**
+     * @param BuilderFactory $factory
+     */
+    public function __construct(BuilderFactory $factory)
+    {
+        parent::__construct($factory);
+    }
+
+    /**
+     * Creates a `setUp` method for initializing test dependencies.
+     *
+     * @param array<int, Expression> $body Statements to include in the `setUp` method body.
+     * @return Method
+     */
+    public function createSetUpMethod(array $body = []): Method
+    {
+        $method = $this->factory->method('setUp')
+            ->makeProtected()
+            ->setReturnType('void');
+
+        $method->addStmt(new Expression(new MethodCall(new Variable('this'), 'parent::setUp')));
+
+        foreach ($body as $stmt) {
+            $method->addStmt($stmt);
+        }
+
+        $this->createDocComment($method, returnType: 'void');
+
+        return $method;
+    }
+
+    /**
+     * Creates a generic test method with optional body statements.
+     *
+     * @param string $methodName The name of the test method.
+     * @param array<int, Stmt> $body Statements to include in the method body.
+     * @return Method
+     */
+    public function createTestMethod(string $methodName, array $body = []): Method
+    {
+        $method = $this->factory->method($methodName)
+            ->makePublic()
+            ->setReturnType('void');
+
+        foreach ($body as $stmt) {
+            $method->addStmt($stmt);
+        }
+
+        $this->createDocComment($method, returnType: 'void');
+
+        return $method;
+    }
+
+    /**
+     * Creates an assertion statement.
+     *
+     * @param string $assertMethod The PHPUnit assertion method (e.g., assertEquals, assertTrue).
+     * @param array<int, mixed> $arguments Arguments for the assertion.
+     * @return Expression
+     */
+    public function createAssertion(string $assertMethod, array $arguments = []): Expression
+    {
+        return new Expression(
+            new MethodCall(new Variable('this'), $assertMethod, $this->createArguments($arguments))
+        );
+    }
+
+    /**
+     * Adds common PHPUnit imports to a test class.
+     *
+     * @param Class_ $class
+     * @param array<string> $imports List of classes to import.
+     * @return Namespace_
+     */
+    public function addTestImports(Class_ $class, array $imports = []): Namespace_
+    {
+        // Create a namespace and add imports
+        return $this->setNamespace('Tests\\Generated', $class, array_merge([
+            'PHPUnit\\Framework\\TestCase',
+            'PhpParser\\BuilderFactory',
+        ], $imports));
+    }
+
+    /**
+     * Creates a fully functional test class.
+     *
+     * @param string $className The name of the test class.
+     * @param array<string, Method> $methods An array of test methods.
+     * @param array<string> $imports List of additional classes to import.
+     * @param array<int, Expression> $setupBody Optional body for the `setUp` method.
+     * @return Class_
+     */
+    public function createTestClass(
+        string $className,
+        array $methods,
+        array $imports = [],
+        array $setupBody = []
+    ): Class_ {
+        $class = $this->createClass($className);
+
+        // Extend TestCase
+        $this->extendClass($class, 'TestCase');
+
+        // Add the setUp method
+        if (!empty($setupBody)) {
+            $class->addStmt($this->createSetUpMethod($setupBody));
+        }
+
+        // Add all test methods
+        foreach ($methods as $methodName => $method) {
+            $class->addStmt($method);
+        }
+
+        // Add imports
+        $this->addTestImports($class, $imports);
+
+        return $class;
+    }
+}

--- a/tests/BasicGeneration/ConvertToAstNodeTest.php
+++ b/tests/BasicGeneration/ConvertToAstNodeTest.php
@@ -7,6 +7,7 @@ namespace BasicGeneration;
 use PhpParser\BuilderFactory;
 use PhpParser\Node\Expr\Array_;
 use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Expr\Variable;
 use PhpParser\Node\Name;
 use PhpParser\Node\Scalar\LNumber;
 use PhpParser\Node\Scalar\String_;
@@ -37,6 +38,8 @@ class ConvertToAstNodeTest extends TestCase
             $this->assertSame($expectedValue, $result->name->toString());
         } elseif ($result instanceof Array_) {
             $this->assertInstanceOf(Array_::class, $result);
+        } elseif ($result instanceof Variable) {
+            $this->assertSame($expectedValue, $result->name);
         }
     }
 
@@ -63,6 +66,9 @@ class ConvertToAstNodeTest extends TestCase
             // Booleans
             [true, ConstFetch::class, 'true'],
             [false, ConstFetch::class, 'false'],
+
+            // Variables
+            [new Variable('testVar'), Variable::class, 'testVar'],
         ];
     }
 
@@ -90,9 +96,6 @@ class ConvertToAstNodeTest extends TestCase
 
             // Resources
             [fopen('php://memory', 'r'), 'Unsupported value type for AST conversion: resource'],
-
-            // Null
-            [null, 'Unsupported value type for AST conversion: NULL'],
 
             // Floats
             [3.14, 'Unsupported value type for AST conversion: double'],

--- a/tests/TestGeneration/AddTestImportsTest.php
+++ b/tests/TestGeneration/AddTestImportsTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestGeneration;
+
+use PhpParser\BuilderFactory;
+use PhpParser\Node\Stmt\Use_;
+use PHPUnit\Framework\TestCase;
+use quintenmbusiness\PhpAstCodeGenerationHelper\GeneratorHelpers\TestGenerationHelper;
+
+class AddTestImportsTest extends TestCase
+{
+    private TestGenerationHelper $helper;
+
+    protected function setUp(): void
+    {
+        $this->helper = new TestGenerationHelper(new BuilderFactory());
+    }
+
+    public function test_adds_default_imports(): void
+    {
+        $class = $this->helper->createClass('ExampleTest');
+        $namespace = $this->helper->addTestImports($class);
+
+        $namespaceNode = $namespace->getNode();
+
+        // Filter only Use_ statements
+        $importStatements = array_values(
+            array_filter($namespaceNode->stmts, fn($stmt) => $stmt instanceof Use_)
+        );
+
+        // Assertions
+        $this->assertCount(2, $importStatements);
+        $this->assertSame('PHPUnit\Framework\TestCase', $importStatements[0]->uses[0]->name->toString());
+        $this->assertSame('PhpParser\BuilderFactory', $importStatements[1]->uses[0]->name->toString());
+    }
+
+    public function test_adds_custom_imports(): void
+    {
+        $class = $this->helper->createClass('ExampleTest');
+        $namespace = $this->helper->addTestImports($class, ['MyNamespace\\MyClass']);
+
+        $namespaceNode = $namespace->getNode();
+
+        // Filter only Use_ statements
+        $importStatements = array_values(
+            array_filter($namespaceNode->stmts, fn($stmt) => $stmt instanceof Use_)
+        );
+
+        // Assertions
+        $this->assertCount(3, $importStatements);
+        $this->assertSame('PHPUnit\Framework\TestCase', $importStatements[0]->uses[0]->name->toString());
+        $this->assertSame('PhpParser\BuilderFactory', $importStatements[1]->uses[0]->name->toString());
+        $this->assertSame('MyNamespace\MyClass', $importStatements[2]->uses[0]->name->toString());
+    }
+}

--- a/tests/TestGeneration/CreateAssertionTest.php
+++ b/tests/TestGeneration/CreateAssertionTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestGeneration;
+
+use PhpParser\BuilderFactory;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\Expression;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Scalar\LNumber;
+use PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Name;
+use PHPUnit\Framework\TestCase;
+use quintenmbusiness\PhpAstCodeGenerationHelper\GeneratorHelpers\TestGenerationHelper;
+
+class CreateAssertionTest extends TestCase
+{
+    private TestGenerationHelper $helper;
+
+    protected function setUp(): void
+    {
+        $this->helper = new TestGenerationHelper(new BuilderFactory());
+    }
+
+    public function test_creates_assertion_statement(): void
+    {
+        $assertion = $this->helper->createAssertion('assertTrue', [true]);
+
+        $this->assertInstanceOf(Expression::class, $assertion);
+        $this->assertInstanceOf(MethodCall::class, $assertion->expr);
+        $this->assertSame('assertTrue', $assertion->expr->name->toString());
+        $this->assertCount(1, $assertion->expr->args);
+
+        // Validate the argument node
+        $arg = $assertion->expr->args[0]->value;
+        $this->assertInstanceOf(ConstFetch::class, $arg);
+        $this->assertSame('true', $arg->name->toString());
+    }
+
+    /**
+     * @dataProvider assertionDataProvider
+     */
+    public function test_creates_various_assertions(string $method, array $arguments, array $expectedArgs): void
+    {
+        $assertion = $this->helper->createAssertion($method, $arguments);
+
+        $this->assertInstanceOf(Expression::class, $assertion);
+        $this->assertInstanceOf(MethodCall::class, $assertion->expr);
+        $this->assertSame($method, $assertion->expr->name->toString());
+        $this->assertCount(count($expectedArgs), $assertion->expr->args);
+
+        foreach ($assertion->expr->args as $index => $arg) {
+            $value = $arg->value;
+
+            if ($value instanceof ConstFetch) {
+                $this->assertSame($expectedArgs[$index], $value->name->toString());
+            } elseif ($value instanceof LNumber || $value instanceof String_) {
+                $this->assertSame($expectedArgs[$index], $value->value);
+            } elseif ($value instanceof Array_) {
+                $this->assertInstanceOf(Array_::class, $value);
+            } elseif ($value instanceof Variable) {
+                $this->assertSame($expectedArgs[$index], $value->name);
+            }
+        }
+    }
+
+    public static function assertionDataProvider(): array
+    {
+        return [
+            'assertTrue' => [
+                'method' => 'assertTrue',
+                'arguments' => [true],
+                'expectedArgs' => ['true'],
+            ],
+            'assertFalse' => [
+                'method' => 'assertFalse',
+                'arguments' => [false],
+                'expectedArgs' => ['false'],
+            ],
+            'assertEquals' => [
+                'method' => 'assertEquals',
+                'arguments' => [42, 42],
+                'expectedArgs' => [42, 42],
+            ],
+            'assertSame' => [
+                'method' => 'assertSame',
+                'arguments' => ['string', 'string'],
+                'expectedArgs' => ['string', 'string'],
+            ],
+            'assertNotEquals' => [
+                'method' => 'assertNotEquals',
+                'arguments' => [10, 20],
+                'expectedArgs' => [10, 20],
+            ],
+            'assertNull' => [
+                'method' => 'assertNull',
+                'arguments' => [null],
+                'expectedArgs' => ['null'], // ConstFetch for null
+            ],
+            'assertCount' => [
+                'method' => 'assertCount',
+                'arguments' => [2, [1, 2]],
+                'expectedArgs' => [2, [1, 2]],
+            ],
+        ];
+    }
+
+    public function test_creates_assertion_with_variable_argument(): void
+    {
+        $variable = new Variable('result');
+        $assertion = $this->helper->createAssertion('assertNotNull', [$variable]);
+
+        $this->assertInstanceOf(Expression::class, $assertion);
+        $this->assertInstanceOf(MethodCall::class, $assertion->expr);
+        $this->assertSame('assertNotNull', $assertion->expr->name->toString());
+
+        $arg = $assertion->expr->args[0]->value;
+        $this->assertInstanceOf(Variable::class, $arg);
+        $this->assertSame('result', $arg->name);
+    }
+}

--- a/tests/TestGeneration/CreateSetUpMethodTest.php
+++ b/tests/TestGeneration/CreateSetUpMethodTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestGeneration;
+
+use PhpParser\BuilderFactory;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Stmt\Expression;
+use PHPUnit\Framework\TestCase;
+use quintenmbusiness\PhpAstCodeGenerationHelper\GeneratorHelpers\TestGenerationHelper;
+
+class CreateSetUpMethodTest extends TestCase
+{
+    private TestGenerationHelper $helper;
+
+    protected function setUp(): void
+    {
+        $this->helper = new TestGenerationHelper(new BuilderFactory());
+    }
+
+    public function test_creates_setup_method_with_parent_call(): void
+    {
+        $method = $this->helper->createSetUpMethod();
+
+        $this->assertSame('setUp', $method->getNode()->name->toString());
+        $this->assertTrue($method->getNode()->isProtected());
+        $this->assertEquals('void', $method->getNode()->getReturnType()->toString());
+
+        $firstStatement = $method->getNode()->stmts[0];
+        $this->assertInstanceOf(Expression::class, $firstStatement);
+        $this->assertInstanceOf(MethodCall::class, $firstStatement->expr);
+        $this->assertSame('parent::setUp', $firstStatement->expr->name->toString());
+    }
+
+    public function test_creates_setup_method_with_body(): void
+    {
+        $body = [new Expression(new MethodCall(new Variable('this'), 'initializeSomething'))];
+        $method = $this->helper->createSetUpMethod($body);
+
+        $this->assertCount(2, $method->getNode()->stmts); // parent::setUp + initializeSomething
+        $this->assertSame('initializeSomething', $method->getNode()->stmts[1]->expr->name->toString());
+    }
+}

--- a/tests/TestGeneration/CreateTestClassTest.php
+++ b/tests/TestGeneration/CreateTestClassTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestGeneration;
+
+use PhpParser\BuilderFactory;
+use PHPUnit\Framework\TestCase;
+use quintenmbusiness\PhpAstCodeGenerationHelper\GeneratorHelpers\TestGenerationHelper;
+
+class CreateTestClassTest extends TestCase
+{
+    private TestGenerationHelper $helper;
+
+    protected function setUp(): void
+    {
+        $this->helper = new TestGenerationHelper(new BuilderFactory());
+    }
+
+    public function test_creates_test_class_with_methods_and_setup(): void
+    {
+        $methods = [
+            'testExample' => $this->helper->createTestMethod('testExample'),
+            'testAnother' => $this->helper->createTestMethod('testAnother'),
+        ];
+
+        $setupBody = [$this->helper->createAssertion('assertNotNull', [new \PhpParser\Node\Expr\Variable('this')])];
+
+        $testClass = $this->helper->createTestClass(
+            'ExampleTest',
+            $methods,
+            ['MyNamespace\\MyClass'],
+            $setupBody
+        );
+
+        $classNode = $testClass->getNode();
+        $this->assertSame('ExampleTest', $classNode->name->toString());
+        $this->assertCount(3, $classNode->stmts); // setUp + 2 test methods
+    }
+}

--- a/tests/TestGeneration/CreateTestMethodTest.php
+++ b/tests/TestGeneration/CreateTestMethodTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TestGeneration;
+
+use PhpParser\BuilderFactory;
+use PhpParser\Node\Stmt\Return_;
+use PHPUnit\Framework\TestCase;
+use quintenmbusiness\PhpAstCodeGenerationHelper\GeneratorHelpers\TestGenerationHelper;
+
+class CreateTestMethodTest extends TestCase
+{
+    private TestGenerationHelper $helper;
+
+    protected function setUp(): void
+    {
+        $this->helper = new TestGenerationHelper(new BuilderFactory());
+    }
+
+    public function test_creates_empty_test_method(): void
+    {
+        $method = $this->helper->createTestMethod('testExample');
+
+        $this->assertSame('testExample', $method->getNode()->name->toString());
+        $this->assertTrue($method->getNode()->isPublic());
+        $this->assertEquals('void', $method->getNode()->getReturnType()->toString());
+        $this->assertEmpty($method->getNode()->stmts);
+    }
+
+    public function test_creates_test_method_with_body(): void
+    {
+        $body = [new Return_()];
+        $method = $this->helper->createTestMethod('testReturn', $body);
+
+        $this->assertCount(1, $method->getNode()->stmts);
+        $this->assertInstanceOf(Return_::class, $method->getNode()->stmts[0]);
+    }
+}


### PR DESCRIPTION
Introduced the TestGenerationHelper class extending ClassGenerationHelper

Implemented a method to generate generic test methods with specified names and body statements

Provided a method to create PHPUnit assertion statements dynamically.

Included functionality to add common PHPUnit imports (TestCase, BuilderFactory) to test classes.

Enabled creation of fully functional test classes with methods, imports, and an optional setUp method body.